### PR TITLE
Secure key storage

### DIFF
--- a/CreateSQLProcedures.ps1
+++ b/CreateSQLProcedures.ps1
@@ -5,6 +5,12 @@ if (!$Config) {
 	exit 1
 }
 
+if ( $null -ne $env:DrmmToPowerBICredentialKey ) {
+	$EncryptionKeyBytes = ( [system.Text.Encoding]::UTF8 ).GetBytes( $env:DrmmToPowerBICredentialKey )
+	$Config.SQLPassword = $Config.SQLPassword | ConvertTo-SecureString -Key $EncryptionKeyBytes |
+	ForEach-Object { [Runtime.InteropServices.Marshal]::PtrToStringAuto( [Runtime.InteropServices.Marshal]::SecureStringToBSTR( $_ ) ) }
+}
+
 # Import Module
 Import-Module SQLServer -Force
 
@@ -14,12 +20,6 @@ $sqlParams = [ordered]@{
 	Database   =  $Config.SQLDatabase
 	User       =  $Config.SQLUser
 	Password   =  $Config.SQLPassword
-}
-
-if ( $null -ne $env:DrmmToPowerBICredentialKey ) {
-	$EncryptionKeyBytes = ( [system.Text.Encoding]::UTF8 ).GetBytes( $env:DrmmToPowerBICredentialKey )
-	$sqlParams.SQLPassword = $sqlParams.SQLPassword | ConvertTo-SecureString -Key $EncryptionKeyBytes |
-	ForEach-Object { [Runtime.InteropServices.Marshal]::PtrToStringAuto( [Runtime.InteropServices.Marshal]::SecureStringToBSTR( $_ ) ) }
 }
 
 # Create SQL Connection String

--- a/CreateSQLProcedures.ps1
+++ b/CreateSQLProcedures.ps1
@@ -16,6 +16,12 @@ $sqlParams = [ordered]@{
 	Password   =  $Config.SQLPassword
 }
 
+if ( $null -ne $env:DrmmToPowerBICredentialKey ) {
+	$EncryptionKeyBytes = ( [system.Text.Encoding]::UTF8 ).GetBytes( $env:DrmmToPowerBICredentialKey )
+	$sqlParams.SQLPassword = $sqlParams.SQLPassword | ConvertTo-SecureString -Key $EncryptionKeyBytes |
+	ForEach-Object { [Runtime.InteropServices.Marshal]::PtrToStringAuto( [Runtime.InteropServices.Marshal]::SecureStringToBSTR( $_ ) ) }
+}
+
 # Create SQL Connection String
 $connString = 'Server={0};Database={1};User Id={2};Password={3};' -f [array]$sqlParams.Values
 

--- a/CreateSQLTables.ps1
+++ b/CreateSQLTables.ps1
@@ -5,6 +5,12 @@ if (!$Config) {
 	exit 1
 }
 
+if ( $null -ne $env:DrmmToPowerBICredentialKey ) {
+	$EncryptionKeyBytes = ( [system.Text.Encoding]::UTF8 ).GetBytes( $env:DrmmToPowerBICredentialKey )
+	$Config.SQLPassword = $Config.SQLPassword | ConvertTo-SecureString -Key $EncryptionKeyBytes |
+	ForEach-Object { [Runtime.InteropServices.Marshal]::PtrToStringAuto( [Runtime.InteropServices.Marshal]::SecureStringToBSTR( $_ ) ) }
+}
+
 # Import Module
 Import-Module SQLServer -Force
 
@@ -14,12 +20,6 @@ $sqlParams = [ordered]@{
 	Database   =  $Config.SQLDatabase
 	User       =  $Config.SQLUser
 	Password   =  $Config.SQLPassword
-}
-
-if ( $null -ne $env:DrmmToPowerBICredentialKey ) {
-	$EncryptionKeyBytes = ( [system.Text.Encoding]::UTF8 ).GetBytes( $env:DrmmToPowerBICredentialKey )
-	$sqlParams.SQLPassword = $sqlParams.SQLPassword | ConvertTo-SecureString -Key $EncryptionKeyBytes |
-	ForEach-Object { [Runtime.InteropServices.Marshal]::PtrToStringAuto( [Runtime.InteropServices.Marshal]::SecureStringToBSTR( $_ ) ) }
 }
 
 # Create SQL Connection String

--- a/CreateSQLTables.ps1
+++ b/CreateSQLTables.ps1
@@ -16,6 +16,12 @@ $sqlParams = [ordered]@{
 	Password   =  $Config.SQLPassword
 }
 
+if ( $null -ne $env:DrmmToPowerBICredentialKey ) {
+	$EncryptionKeyBytes = ( [system.Text.Encoding]::UTF8 ).GetBytes( $env:DrmmToPowerBICredentialKey )
+	$sqlParams.SQLPassword = $sqlParams.SQLPassword | ConvertTo-SecureString -Key $EncryptionKeyBytes |
+	ForEach-Object { [Runtime.InteropServices.Marshal]::PtrToStringAuto( [Runtime.InteropServices.Marshal]::SecureStringToBSTR( $_ ) ) }
+}
+
 # Create SQL Connection String
 $connString = 'Server={0};Database={1};User Id={2};Password={3};' -f [array]$sqlParams.Values
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ You'll need a Microsoft SQL Server to store the Datto RMM data.  You can downloa
 ## API
 You'll need to create API keys to run the PowerShell scripts.  Find more information how to create API keys in the [Datto Online Help](https://help.aem.autotask.net/en/Content/2SETUP/APIv2.htm).  Store the API keys in the provide registry file.
 # Scripts
+## Set Config
+You only need to run this [script](https://github.com/aaronengels/DrmmToPowerBI/blob/main/Set-Config.ps1) once. It is an interactive script that sets registry values for you based on your input. It also allows you to encrypt your SQL password and Datto RMM API Secret Key so it is not stored in plaintext in the registry. If you do opt to encrypt, this script will provide you with the randomly generated encryption key. In order to run the remaining scripts, you will need to provide that key in the form of the variable `$env:DrmmToPowerBICredentialKey` (this is designed so that you can store the key in the Datto RMM system as a masked account variable and run UpdateSQLTables.ps1 as a component).
 ## Create SQL Tables
 You only need to run this [script](https://github.com/aaronengels/DrmmToPowerBI/blob/main/CreateSQLTables.ps1) once.  Alternatively run the [query](https://github.com/aaronengels/DrmmToPowerBI/blob/main/CreateSQLTables.sql) directly in SQL to create the tables in the database.  I decided to create a simple database [schema](https://github.com/aaronengels/DrmmToPowerBI/blob/main/SQLTables.jpg) that can be used easly to create dashboards and reports in Microsoft PowerBI.
 ## Create SQL Procedures

--- a/Set-Config.ps1
+++ b/Set-Config.ps1
@@ -1,0 +1,50 @@
+$SQLServer = Read-Host "SQL Server"
+$SQLDatabase = Read-Host "SQL Database"
+$SQLUser = Read-Host "SQL User"
+$SQLPassword = Read-Host "SQL Password"
+$APIUrl = Read-Host "API Url"
+$APIKey = Read-Host "API Access Key"
+$APISecretKey = Read-Host "API Secret Key"
+[string]$Encrypt = Read-Host "Store passwords in encrypted format? [Y]es or [N]o"
+
+if ( $Encrypt.Substring(0,1).ToLower() -eq 'y' ) {
+    Function New-EncryptedString {
+        param (
+            [string]$PlainText,
+            [Byte[]]$EncryptionKeyBytes
+        )
+        
+        $SecureString = New-Object System.Security.SecureString
+        foreach ( $Char in $PlainText.toCharArray() ) {
+            $SecureString.AppendChar( $Char ) 
+        }
+        Return ConvertFrom-SecureString -SecureString $SecureString -Key $EncryptionKeyBytes
+    }
+
+    $EncryptionKey = ( -join ((0x30..0x39) + ( 0x41..0x5A) + ( 0x61..0x7A) | Get-Random -Count 32 | ForEach-Object {[char]$_}) )
+    $EncryptionKeyBytes = ([system.Text.Encoding]::UTF8).GetBytes($EncryptionKey)
+    $SQLPassword = New-EncryptedString -PlainText $SQLPassword -EncryptionKeyBytes $EncryptionKeyBytes
+    $APISecretKey = New-EncryptedString -PlainText $APISecretKey -EncryptionKeyBytes $EncryptionKeyBytes
+
+    Write-Host "Your encryption key is `n`n$EncryptionKey`n`nWhen running UpdateSQLTables.ps1 pass this value as `$env:DrmmToPowerBICredentialKey.`nIf you lose it it cannot be recovered."
+}
+
+Function Set-RegistryKeyValue {
+    param (
+        [string]$Path,
+        [string]$Key,
+        [string]$Value
+    )
+    if ( !( Test-Path $Path ) ) {
+        New-Item -Path $Path -Force | Out-Null
+    }
+    New-ItemProperty -Path $Path -Name $Key -Value $Value -PropertyType "Unknown" -Force | Out-Null
+}
+
+Set-RegistryKeyValue -Path "HKLM:\SOFTWARE\DrmmToPowerBI" -Key "SQLServer" -Value $SQLServer
+Set-RegistryKeyValue -Path "HKLM:\SOFTWARE\DrmmToPowerBI" -Key "SQLDatabase" -Value $SQLDatabase
+Set-RegistryKeyValue -Path "HKLM:\SOFTWARE\DrmmToPowerBI" -Key "SQLUser" -Value $SQLUser
+Set-RegistryKeyValue -Path "HKLM:\SOFTWARE\DrmmToPowerBI" -Key "SQLPassword" -Value $SQLPassword
+Set-RegistryKeyValue -Path "HKLM:\SOFTWARE\DrmmToPowerBI" -Key "APIUrl" -Value $APIUrl
+Set-RegistryKeyValue -Path "HKLM:\SOFTWARE\DrmmToPowerBI" -Key "APIKey" -Value $APIKey
+Set-RegistryKeyValue -Path "HKLM:\SOFTWARE\DrmmToPowerBI" -Key "APISecretKey" -Value $APISecretKey

--- a/UpdateSQLTables.ps1
+++ b/UpdateSQLTables.ps1
@@ -8,6 +8,13 @@
 			Write-Host 'Registry keys not found. Please import DrmmToPowerBI.reg first!'
 			exit 1
 		}
+		if ( $null -ne $env:DrmmToPowerBICredentialKey ) {
+			$EncryptionKeyBytes = ( [system.Text.Encoding]::UTF8 ).GetBytes( $env:DrmmToPowerBICredentialKey )
+			$Config.SQLPassword = $Config.SQLPassword | ConvertTo-SecureString -Key $EncryptionKeyBytes |
+			ForEach-Object { [Runtime.InteropServices.Marshal]::PtrToStringAuto( [Runtime.InteropServices.Marshal]::SecureStringToBSTR( $_ ) ) }
+			$Config.APISecretKey = $Config.APISecretKey | ConvertTo-SecureString -Key $EncryptionKeyBytes |
+			ForEach-Object { [Runtime.InteropServices.Marshal]::PtrToStringAuto( [Runtime.InteropServices.Marshal]::SecureStringToBSTR( $_ ) ) }
+		}
 				
 		# Import Datto RMM Module
 		Import-Module DattoRMM -Force


### PR DESCRIPTION
Added a script that the user can run during deployment that sets the registry keys. This script allows the user to opt in to key encryption, in which case the SQL Password and the Datto RMM API key are stored as encrypted strings rather than plaintext.

When running scripts that interact with the database and/or the API, the script checks for the encryption key and if it exists it uses it to decrypt the credentials, and if not it proceeds as normal. The script checks for the encryption key in the variable $env:DrmmToPowerBICredentialKey, which lends itself to being passed as a masked account variable in Datto RMM.