### PR TITLE
Suppress errors when SQLPS is not imported

### DIFF
--- a/CreateSQLProcedures.ps1
+++ b/CreateSQLProcedures.ps1
@@ -6,7 +6,7 @@ if (!$Config) {
 }
 
 # Import Module
-Remove-Module SQLPS
+Remove-Module SQLPS -ErrorAction SilentlyContinue
 Import-Module SQLServer -Force
 
 # Create SQL Connection Parameters

--- a/CreateSQLTables.ps1
+++ b/CreateSQLTables.ps1
@@ -6,7 +6,7 @@ if (!$Config) {
 }
 
 # Import Module
-Remove-Module SQLPS
+Remove-Module SQLPS -ErrorAction SilentlyContinue
 Import-Module SQLServer -Force
 
 # Create SQL Connection Parameters

--- a/UpdateSQLTables.ps1
+++ b/UpdateSQLTables.ps1
@@ -10,7 +10,7 @@
 		}
 				
 		# Import Datto RMM Module
-		Remove-Module SQLPS
+		Remove-Module SQLPS -ErrorAction SilentlyContinue
 		Import-Module DattoRMM -Force
 		
 		# Set Datto RMM API Parameters
@@ -24,7 +24,6 @@
 		Set-DrmmApiParameters @apiParams -ErrorAction Stop
 
 		# Import SQL Server Module
-		Remove-Module PSSql
 		Import-Module SQLServer -Force
 
 		# Create SQL Connection Parameters


### PR DESCRIPTION
In the case that SQLPS is not imported, Remove-Module will output an error message. This update suppresses that useless messaging.